### PR TITLE
[ASSET-10] Set unknown asset ID to each network

### DIFF
--- a/libraries/models/network.py
+++ b/libraries/models/network.py
@@ -22,6 +22,8 @@ class Network(CamelCaseModel):
         network: type of the network. (:class:`NetworkType`)
         tags: tags of the network.
               (:class:`TagList`: constrained :class:`list` of :class:`Tag`.)
+        unknown_asset_id: ID of the unknown asset of the network.
+                          (:class:`Id`: constrained :class:`str`.)
     """
 
     currency: Currency
@@ -32,3 +34,4 @@ class Network(CamelCaseModel):
     name: str
     network: NetworkType
     tags: TagList
+    unknown_asset_id: Id

--- a/networks/evm-1/info.json
+++ b/networks/evm-1/info.json
@@ -33,5 +33,6 @@
   "network": "mainnet",
   "tags": [
     "ethereum"
-  ]
+  ],
+  "unknownAssetId": "unknown-ethereum"
 }

--- a/networks/evm-10/info.json
+++ b/networks/evm-10/info.json
@@ -34,5 +34,6 @@
   "tags": [
     "l2-ethereum",
     "optimism"
-  ]
+  ],
+  "unknownAssetId": "unknown-optimism"
 }

--- a/networks/evm-1001/info.json
+++ b/networks/evm-1001/info.json
@@ -25,5 +25,6 @@
   "network": "testnet",
   "tags": [
     "klaytn"
-  ]
+  ],
+  "unknownAssetId": "unknown-klaytn"
 }

--- a/networks/evm-11155111/info.json
+++ b/networks/evm-11155111/info.json
@@ -34,5 +34,6 @@
   "tags": [
     "ethereum",
     "sepolia"
-  ]
+  ],
+  "unknownAssetId": "unknown-ethereum"
 }

--- a/networks/evm-11155420/info.json
+++ b/networks/evm-11155420/info.json
@@ -31,5 +31,6 @@
     "l2-ethereum",
     "optimism",
     "sepolia"
-  ]
+  ],
+  "unknownAssetId": "unknown-optimism"
 }

--- a/networks/evm-137/info.json
+++ b/networks/evm-137/info.json
@@ -33,5 +33,6 @@
   "network": "mainnet",
   "tags": [
     "polygon"
-  ]
+  ],
+  "unknownAssetId": "unknown-polygon"
 }

--- a/networks/evm-3068/info.json
+++ b/networks/evm-3068/info.json
@@ -25,5 +25,6 @@
   "network": "mainnet",
   "tags": [
     "bifrost"
-  ]
+  ],
+  "unknownAssetId": "unknown-bifrost"
 }

--- a/networks/evm-420/info.json
+++ b/networks/evm-420/info.json
@@ -31,5 +31,6 @@
     "goerli",
     "l2-ethereum",
     "optimism"
-  ]
+  ],
+  "unknownAssetId": "unknown-optimism"
 }

--- a/networks/evm-42161/info.json
+++ b/networks/evm-42161/info.json
@@ -30,5 +30,6 @@
   "tags": [
     "arbitrum",
     "l2-ethereum"
-  ]
+  ],
+  "unknownAssetId": "unknown-arbitrum"
 }

--- a/networks/evm-421613/info.json
+++ b/networks/evm-421613/info.json
@@ -22,5 +22,6 @@
     "arbitrum",
     "goerli",
     "l2-ethereum"
-  ]
+  ],
+  "unknownAssetId": "unknown-arbitrum"
 }

--- a/networks/evm-421614/info.json
+++ b/networks/evm-421614/info.json
@@ -31,5 +31,6 @@
     "arbitrum",
     "l2-ethereum",
     "sepolia"
-  ]
+  ],
+  "unknownAssetId": "unknown-arbitrum"
 }

--- a/networks/evm-43113/info.json
+++ b/networks/evm-43113/info.json
@@ -25,5 +25,6 @@
   "network": "testnet",
   "tags": [
     "avalanche"
-  ]
+  ],
+  "unknownAssetId": "unknown-avalanche"
 }

--- a/networks/evm-43114/info.json
+++ b/networks/evm-43114/info.json
@@ -25,5 +25,6 @@
   "network": "mainnet",
   "tags": [
     "avalanche"
-  ]
+  ],
+  "unknownAssetId": "unknown-avalanche"
 }

--- a/networks/evm-49088/info.json
+++ b/networks/evm-49088/info.json
@@ -25,5 +25,6 @@
   "network": "testnet",
   "tags": [
     "bifrost"
-  ]
+  ],
+  "unknownAssetId": "unknown-bifrost"
 }

--- a/networks/evm-5/info.json
+++ b/networks/evm-5/info.json
@@ -30,5 +30,6 @@
   "tags": [
     "ethereum",
     "goerli"
-  ]
+  ],
+  "unknownAssetId": "unknown-ethereum"
 }

--- a/networks/evm-56/info.json
+++ b/networks/evm-56/info.json
@@ -29,5 +29,6 @@
   "network": "mainnet",
   "tags": [
     "bnb"
-  ]
+  ],
+  "unknownAssetId": "unknown-bnb"
 }

--- a/networks/evm-80001/info.json
+++ b/networks/evm-80001/info.json
@@ -25,5 +25,6 @@
   "network": "testnet",
   "tags": [
     "polygon"
-  ]
+  ],
+  "unknownAssetId": "unknown-polygon"
 }

--- a/networks/evm-8217/info.json
+++ b/networks/evm-8217/info.json
@@ -25,5 +25,6 @@
   "network": "mainnet",
   "tags": [
     "klaytn"
-  ]
+  ],
+  "unknownAssetId": "unknown-klaytn"
 }

--- a/networks/evm-8453/info.json
+++ b/networks/evm-8453/info.json
@@ -34,5 +34,6 @@
   "tags": [
     "base",
     "l2-ethereum"
-  ]
+  ],
+  "unknownAssetId": "unknown-base"
 }

--- a/networks/evm-84531/info.json
+++ b/networks/evm-84531/info.json
@@ -31,5 +31,6 @@
     "base",
     "goerli",
     "l2-ethereum"
-  ]
+  ],
+  "unknownAssetId": "unknown-base"
 }

--- a/networks/evm-84532/info.json
+++ b/networks/evm-84532/info.json
@@ -31,5 +31,6 @@
     "base",
     "l2-ethereum",
     "sepolia"
-  ]
+  ],
+  "unknownAssetId": "unknown-base"
 }

--- a/networks/evm-97/info.json
+++ b/networks/evm-97/info.json
@@ -25,5 +25,6 @@
   "network": "testnet",
   "tags": [
     "bnb"
-  ]
+  ],
+  "unknownAssetId": "unknown-bnb"
 }

--- a/networks/unknown/info.json
+++ b/networks/unknown/info.json
@@ -18,5 +18,6 @@
   },
   "name": "Unknown Network",
   "network": "unknown",
-  "tags": []
+  "tags": [],
+  "unknownAssetId": "unknown"
 }

--- a/tests/validity/test_network.py
+++ b/tests/validity/test_network.py
@@ -1,3 +1,4 @@
+import re
 from typing import Tuple
 
 from libraries.models.asset import Asset
@@ -95,3 +96,16 @@ class TestValidityNetwork:
         for network, _ in self.network_list:
             for tag in network.tags:
                 assert tag in tag_value_list
+
+    def test_all_unknown_asset_id_in_asset_list(self):
+        """All unknown asset ID in network information has an asset which is
+        described in the asset information `asset.json`."""
+        asset_id_list = [item.id for item, _ in self.asset_list]
+        for network, _ in self.network_list:
+            assert network.unknown_asset_id in asset_id_list
+            match re.match(r"^unknown-(.+)$", network.unknown_asset_id):
+                case match if match is not None:
+                    print(match.group(1))
+                    assert match.group(1) in network.tags
+                case None:
+                    pass


### PR DESCRIPTION
# Pull Request

## Description

각 network에 unknown asset ID를 세팅합니다.
이를 통해 각 인지된 network 는 별도의 unknown asset icon을 사용할 수 있도록 합니다. 

Related issue: [ASSET-10](https://pi-lab.atlassian.net/browse/ASSET-10)

### Changes

- [4f1d1b8](https://github.com/bifrost-platform/asset-info-v2/pull/11/commits/4f1d1b8cb9fab745c0a227dc2e9e46cd4af975bf): Unknwon asset ID field 추가
- [fb581f1](https://github.com/bifrost-platform/asset-info-v2/pull/11/commits/fb581f1c06076fbe8a218c86f786e99a6708741b): Test 추가

### Types of Changes (multiple options can be selected)

- [ ] Create asset information
- [ ] Update asset information
- [ ] Delete asset information
- [x] Other `Update asset info`

## Checklist

- [x] Did you pass the tests?
- [x] Did you run the pre-process?
- [x] Have you added and run tests to validate the changes?


[ASSET-10]: https://pi-lab.atlassian.net/browse/ASSET-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ