### PR TITLE
[ASSET-13] Add WBTC and BTCB on testnet

### DIFF
--- a/assets/btcb-0/info.json
+++ b/assets/btcb-0/info.json
@@ -11,6 +11,16 @@
       ]
     },
     {
+      "address": "0xa4BDE980dAAbDf9861F87ea89d4854a5FF062755",
+      "decimals": 18,
+      "name": "Unified BTCB",
+      "network": "evm-49088",
+      "symbol": "BTCB",
+      "tags": [
+        "testnet"
+      ]
+    },
+    {
       "address": "0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c",
       "decimals": 18,
       "name": "BTCB Token",
@@ -18,6 +28,16 @@
       "symbol": "BTCB",
       "tags": [
         "mainnet"
+      ]
+    },
+    {
+      "address": "0xCb3BCc6300D416A96b6FAD1814C00Af0031EFff0",
+      "decimals": 18,
+      "name": "BTCB Token",
+      "network": "evm-97",
+      "symbol": "BTCB",
+      "tags": [
+        "testnet"
       ]
     }
   ],

--- a/assets/wbtc-0/info.json
+++ b/assets/wbtc-0/info.json
@@ -21,6 +21,16 @@
       ]
     },
     {
+      "address": "0xfb227D3d049a2cdB7b5b75D5227B50219eDe3224",
+      "decimals": 8,
+      "name": "Wrapped BTC",
+      "network": "evm-11155111",
+      "symbol": "WBTC",
+      "tags": [
+        "testnet"
+      ]
+    },
+    {
       "address": "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6",
       "decimals": 8,
       "name": "(PoS) Wrapped BTC",
@@ -41,6 +51,16 @@
       ]
     },
     {
+      "address": "0xdD3B4c386729aE16dA6F961d7E0d4775C28ecA09",
+      "decimals": 8,
+      "name": "Wrapped BTC",
+      "network": "evm-421614",
+      "symbol": "WBTC",
+      "tags": [
+        "testnet"
+      ]
+    },
+    {
       "address": "0x408D4cD0ADb7ceBd1F1A1C33A0Ba2098E1295bAB",
       "decimals": 8,
       "name": "Wrapped BTC",
@@ -58,6 +78,26 @@
       "symbol": "WBTC.e",
       "tags": [
         "mainnet"
+      ]
+    },
+    {
+      "address": "0xb710c446E2e4e162D734580Bd6f13725c345E1F7",
+      "decimals": 8,
+      "name": "Unified WBTC",
+      "network": "evm-49088",
+      "symbol": "WBTC",
+      "tags": [
+        "testnet"
+      ]
+    },
+    {
+      "address": "0x8ed42D9ae83213813AB077B71a80b9331FB690A2",
+      "decimals": 8,
+      "name": "Wrapped BTC",
+      "network": "evm-80001",
+      "symbol": "WBTC",
+      "tags": [
+        "testnet"
       ]
     }
   ],


### PR DESCRIPTION
# Pull Request

## Description

CCCP에서 지원할 WBTC, BTCB의 address를 추가합니다.

Related issue: [ASSET-13](https://pi-lab.atlassian.net/browse/ASSET-13)

### Changes

- [ecb12ba](https://github.com/bifrost-platform/asset-info-v2/pull/14/commits/ecb12ba073004a5242eeba893706661d0401fca2): WBTC, BTCB 정보 추가

### Types of Changes (multiple options can be selected)

- [ ] Create asset information
- [x] Update asset information
- [ ] Delete asset information
- [ ] Other `{{Please add description here}}`

## Checklist

- [x] Did you pass the tests?
- [x] Did you run the pre-process?
- [x] Have you added and run tests to validate the changes?
- [x] Have you updated the documentation?
- [x] Have you updated the version in `setup.py` if you need?


[ASSET-13]: https://pi-lab.atlassian.net/browse/ASSET-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ