### PR TITLE
[ASSET-13] Add WBTC and BTCB on mainnet

### DIFF
--- a/assets/btcb-0/info.json
+++ b/assets/btcb-0/info.json
@@ -1,6 +1,16 @@
 {
   "contracts": [
     {
+      "address": "0xd267F821F1b8344B5A63626c8c824697194A173E",
+      "decimals": 18,
+      "name": "Unified BTCB",
+      "network": "evm-3068",
+      "symbol": "BTCB",
+      "tags": [
+        "mainnet"
+      ]
+    },
+    {
       "address": "0x152b9d0FdC40C096757F570A51E494bd4b943E50",
       "decimals": 8,
       "name": "Bitcoin",

--- a/assets/wbtc-0/info.json
+++ b/assets/wbtc-0/info.json
@@ -41,6 +41,16 @@
       ]
     },
     {
+      "address": "0x7b8FAC5F29E101BaaB33c5f9c39d4F85ba2cc7C1",
+      "decimals": 8,
+      "name": "Unified WBTC",
+      "network": "evm-3068",
+      "symbol": "WBTC",
+      "tags": [
+        "mainnet"
+      ]
+    },
+    {
       "address": "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
       "decimals": 8,
       "name": "Wrapped BTC",


### PR DESCRIPTION
# Pull Request

## Description

CCCP에서 지원할 WBTC, BTCB의 address를 추가합니다.

Related issue: [ASSET-14](https://pi-lab.atlassian.net/browse/ASSET-14)

### Changes

- [ab0cfdc](https://github.com/bifrost-platform/asset-info-v2/pull/15/commits/ab0cfdc8dfa9cd66e5f57790997b51a04e8364a1): WBTC 추가
- [510d587](https://github.com/bifrost-platform/asset-info-v2/pull/15/commits/510d587eca13b5cd3d281d8bbdc5449dc71d22f9): BTCB 추가

### Types of Changes (multiple options can be selected)

- [ ] Create asset information
- [x] Update asset information
- [ ] Delete asset information
- [ ] Other `{{Please add description here}}`

## Checklist

- [x] Did you pass the tests?
- [x] Did you run the pre-process?
- [x] Have you added and run tests to validate the changes?
- [x] Have you updated the documentation?
- [x] Have you updated the version in `setup.py` if you need?


[ASSET-14]: https://pi-lab.atlassian.net/browse/ASSET-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ