### PR TITLE
[ASSET-19] Fix the required version comparison specifier of pydantic

### DIFF
--- a/requirements/essential.txt
+++ b/requirements/essential.txt
@@ -1,2 +1,2 @@
 # Specifies the essential requirements of the project.
-pydantic==2.5.3
+pydantic>=2.5.3


### PR DESCRIPTION
# Pull Request

## Description

본 repository를 이용하는 다른 project의 `pydantic` version 자율성을 위하여
`pydantic` 의 required version comparison specifier를 수정합니다.

Related issue: [ASSET-19](https://pi-lab.atlassian.net/browse/ASSET-19)

### Changes

- [`d8174f9`](https://github.com/bifrost-platform/asset-info-v2/pull/20/commits/d8174f95ac291f53c7484cc2a108e803ed6f2b4d): version comparison specifier 수정

### Types of Changes (multiple options can be selected)

- [ ] Create asset information
- [ ] Update asset information
- [ ] Delete asset information
- [x] Other `Fix project setting`

## Checklist

- [x] Did you pass the tests?
- [x] Did you run the pre-process?
- [x] Have you added and run tests to validate the changes?
- [x] Have you updated the documentation?
- [x] Have you updated the version in `setup.py` if you need?


[ASSET-19]: https://pi-lab.atlassian.net/browse/ASSET-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ