### PR TITLE
[ASSET-37] feat: introduce "wrapped-coin" tag

### DIFF
--- a/assets/wavax-0/info.json
+++ b/assets/wavax-0/info.json
@@ -7,7 +7,8 @@
       "network": "evm-43114",
       "symbol": "WAVAX",
       "tags": [
-        "mainnet"
+        "mainnet",
+        "wrapped-coin"
       ]
     }
   ],

--- a/assets/wbfc-0/info.json
+++ b/assets/wbfc-0/info.json
@@ -7,7 +7,8 @@
       "network": "evm-3068",
       "symbol": "WBFC",
       "tags": [
-        "mainnet"
+        "mainnet",
+        "wrapped-coin"
       ]
     },
     {
@@ -17,7 +18,8 @@
       "network": "evm-49088",
       "symbol": "WBFC",
       "tags": [
-        "testnet"
+        "testnet",
+        "wrapped-coin"
       ]
     }
   ],

--- a/assets/wbnb-0/info.json
+++ b/assets/wbnb-0/info.json
@@ -7,7 +7,8 @@
       "network": "evm-56",
       "symbol": "WBNB",
       "tags": [
-        "mainnet"
+        "mainnet",
+        "wrapped-coin"
       ]
     },
     {
@@ -17,7 +18,8 @@
       "network": "evm-97",
       "symbol": "WBNB",
       "tags": [
-        "testnet"
+        "testnet",
+        "wrapped-coin"
       ]
     }
   ],

--- a/assets/weth-0/info.json
+++ b/assets/weth-0/info.json
@@ -7,7 +7,8 @@
       "network": "evm-1",
       "symbol": "WETH",
       "tags": [
-        "mainnet"
+        "mainnet",
+        "wrapped-coin"
       ]
     },
     {
@@ -17,7 +18,8 @@
       "network": "evm-10",
       "symbol": "WETH",
       "tags": [
-        "mainnet"
+        "mainnet",
+        "wrapped-coin"
       ]
     },
     {
@@ -37,7 +39,8 @@
       "network": "evm-42161",
       "symbol": "WETH",
       "tags": [
-        "mainnet"
+        "mainnet",
+        "wrapped-coin"
       ]
     },
     {
@@ -67,7 +70,8 @@
       "network": "evm-8453",
       "symbol": "WETH",
       "tags": [
-        "mainnet"
+        "mainnet",
+        "wrapped-coin"
       ]
     }
   ],

--- a/assets/wklay-0/info.json
+++ b/assets/wklay-0/info.json
@@ -7,7 +7,8 @@
       "network": "evm-8217",
       "symbol": "WKLAY",
       "tags": [
-        "mainnet"
+        "mainnet",
+        "wrapped-coin"
       ]
     }
   ],

--- a/assets/wmatic-0/info.json
+++ b/assets/wmatic-0/info.json
@@ -7,7 +7,8 @@
       "network": "evm-137",
       "symbol": "WMATIC",
       "tags": [
-        "mainnet"
+        "mainnet",
+        "wrapped-coin"
       ]
     },
     {

--- a/enums/tags/asset.contracts.json
+++ b/enums/tags/asset.contracts.json
@@ -14,5 +14,9 @@
   {
     "value": "unknown",
     "description": "This asset contract is deployed at unknown network"
+  },
+  {
+    "value": "wrapped-coin",
+    "description": "Wrapped coin of some network"
   }
 ]


### PR DESCRIPTION
# Pull Request

Chainrunner-v2 작업중, 지원 하는 asset을 분류해야 되는 need가 발생.
분류 과정 중, asset이 wrapped coin인지 여부를 지정 해야함
위 과정을 위해 manual하게 특정 네트워크의 특정 코인을 wrapped-coin으로 표시해준다.

## Description

Related issue: [ASSET-37](https://pi-lab.atlassian.net/browse/ASSET-37)

### Changes

[Chainrunner](https://github.com/bifrost-platform/Gourmet-TestDriver/tree/develop/src/Procedure/Library/Base/Asset/AssetMap)에 wrapped-coin으로 지정된 asset의 tags에 "wrapped-coin"을 추가한다


### Types of Changes (multiple options can be selected)

- [ ] Create asset information
- [x] Update asset information
- [ ] Delete asset information
- [ ] Other `{{Please add description here}}`

## Checklist

- [ ] Did you pass the tests? (Did you execute `pytest -l` in your PC and get a green light?)
- [ ] Did you run the pre-process?
- [ ] Have you added and run tests to validate the changes?
- [ ] Have you updated the documentation?
- [ ] Have you updated the version in `{PWD}/VERSION` if you need?


[ASSET-37]: https://pi-lab.atlassian.net/browse/ASSET-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ