### PR TITLE
[ASSET-42] Add Bifrost mainnet Unified BTC

### DIFF
--- a/assets/btc-1/info.json
+++ b/assets/btc-1/info.json
@@ -1,6 +1,16 @@
 {
   "contracts": [
     {
+      "address": "0xB000F62Ae7FB5E1D93E7358258B1abA754E0166A",
+      "decimals": 8,
+      "name": "Unified BTC",
+      "network": "evm-3068",
+      "symbol": "BTC",
+      "tags": [
+        "mainnet"
+      ]
+    },
+    {
       "address": "0x52Eb8CFC008814328cF8daec9e2023Fb58384242",
       "decimals": 8,
       "name": "Unified BTC",

--- a/libraries/constants/rpc.json
+++ b/libraries/constants/rpc.json
@@ -9,7 +9,7 @@
   },
   {
     "id": "evm-1001",
-    "url": "https://public-rpc.thebifrost.io/test/klaytn"
+    "url": "https://public-rpc.thebifrost.io/test/kaia"
   },
   {
     "id": "evm-11155111",
@@ -73,7 +73,7 @@
   },
   {
     "id": "evm-8217",
-    "url": "https://public-rpc.thebifrost.io/main/klaytn"
+    "url": "https://public-rpc.thebifrost.io/main/kaia"
   },
   {
     "id": "evm-8453",

--- a/tests/additional/test_rpc.py
+++ b/tests/additional/test_rpc.py
@@ -59,8 +59,10 @@ class TestAdditionalRpc:
         if node_url := self.rpc_map.get(network.id, None):
             if network.engine.is_evm:
                 node = Web3(HTTPProvider(node_url))
-                assert node.is_connected()
-                assert node.eth.chain_id == int(str(network.id).removeprefix("evm-"))
+                assert node.is_connected(), f"The node ${network.id} is not connected."
+                assert node.eth.chain_id == int(
+                    str(network.id).removeprefix("evm-")
+                ), "The chain ID ${node.eth.chain_id} does not match the network ID ${network.id}."
             else:
                 pass
         else:


### PR DESCRIPTION
# Pull Request

## Description

Bifrost mainnet의 Unified BTC를 추가합니다.

Related issue: [ASSET-42](https://pi-lab.atlassian.net/browse/ASSET-42)

### Changes

- [`32797b5`](https://github.com/bifrost-platform/asset-info-v2/pull/48/commits/32797b5420fad570b51045c5ba2aa2c6aa13b439): Unified BTC 추가
- [`b0fbf80`](https://github.com/bifrost-platform/asset-info-v2/pull/48/commits/b0fbf8019cb6b9c72aa7cf58709e4eb2964c27d4): RPC map test 오류 수정

### Types of Changes (multiple options can be selected)

- [x] Create asset information
- [ ] Update asset information
- [ ] Delete asset information
- [x] Other `Fix test`

## Checklist

- [x] Did you pass the tests? (Did you execute `pytest -l` in your PC and get a green light?)
- [x] Did you run the pre-process?
- [x] Have you added and run tests to validate the changes?
- [x] Have you updated the documentation?
- [x] Have you updated the version in `{PWD}/VERSION` if you need?


[ASSET-42]: https://pi-lab.atlassian.net/browse/ASSET-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ