### PR TITLE
[ASSET-48] Add new stBFC, wstBFC tokens in Testnet

### DIFF
--- a/assets/stbfc-0/info.json
+++ b/assets/stbfc-0/info.json
@@ -11,6 +11,16 @@
       ]
     },
     {
+      "address": "0x14FB9a0af25aE3c958e03A06f0939987cf3d2285",
+      "decimals": 18,
+      "name": "Staked BFC",
+      "network": "evm-49088",
+      "symbol": "stBFC",
+      "tags": [
+        "testnet"
+      ]
+    },
+    {
       "address": "0xF14804603D150f009893DcBaF0fca4d7B2B8394B",
       "decimals": 18,
       "name": "Staked BFC",

--- a/assets/wstbfc-0/info.json
+++ b/assets/wstbfc-0/info.json
@@ -23,7 +23,7 @@
     {
       "address": "0xe6E4bb02EC95a770fdCfe20Fe6bB4BDF1eA3943C",
       "decimals": 18,
-      "name": "Wrapped liquid staked BFCer 2.0",
+      "name": "Wrapped liquid staked BFC",
       "network": "evm-49088",
       "symbol": "wstBFC",
       "tags": [

--- a/assets/wstbfc-0/info.json
+++ b/assets/wstbfc-0/info.json
@@ -19,6 +19,16 @@
       "tags": [
         "testnet"
       ]
+    },
+    {
+      "address": "0xe6E4bb02EC95a770fdCfe20Fe6bB4BDF1eA3943C",
+      "decimals": 18,
+      "name": "Wrapped liquid staked BFCer 2.0",
+      "network": "evm-49088",
+      "symbol": "wstBFC",
+      "tags": [
+        "testnet"
+      ]
     }
   ],
   "id": "wstbfc-0",


### PR DESCRIPTION
# Pull Request

## Description

stBFC와 wstBFC가 토큰 설정 문제로 재배포되어 이를 반영합니다.

Related issue: [ASSET-48](https://pi-lab.atlassian.net/browse/ASSET-48)

### Changes

- [`0a76b7d`](https://github.com/bifrost-platform/asset-info-v2/pull/54/commits/0a76b7d01b3fa2606a5ae00f595eabe2ecf2644d): Contract 정보 추가

### Types of Changes (multiple options can be selected)

- [ ] Create asset information
- [x] Update asset information
- [ ] Delete asset information
- [ ] Other `{{Please add description here}}`

## Checklist

- [x] Did you pass the tests? (Did you execute `pytest -l -all` in your PC and get a green light?)
- [x] Did you run the pre-process?
- [x] Have you added and run tests to validate the changes?
- [x] Have you updated the documentation?
- [x] Have you updated the version in `{PWD}/VERSION` if you need?


[ASSET-48]: https://pi-lab.atlassian.net/browse/ASSET-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ