### PR TITLE
[ASSET-50] Log public IP when RPC Test failure 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,4 @@ jobs:
         run: pip install -e ".[test]"
 
       - name: Test
-        run: pytest -l
+        run: pytest -l -vv

--- a/tests/additional/test_rpc.py
+++ b/tests/additional/test_rpc.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from re import search
 
 import pytest
+import requests
 from git import Repo
 from pydantic import HttpUrl
 from web3 import Web3, HTTPProvider
@@ -61,7 +62,11 @@ class TestAdditionalRpc:
         if node_url := self.rpc_map.get(network.id, None):
             if network.engine.is_evm:
                 node = Web3(HTTPProvider(node_url))
-                assert node.is_connected(), f"The node ${network.id} is not connected."
+                if not node.is_connected():
+                    public_ip = requests.get("https://api.ipify.org").text
+                    assert (
+                        node.is_connected()
+                    ), f"The node ${network.id} is not connected. (Public IP: ${public_ip})"
                 assert node.eth.chain_id == int(
                     str(network.id).removeprefix("evm-")
                 ), "The chain ID ${node.eth.chain_id} does not match the network ID ${network.id}."


### PR DESCRIPTION
# Pull Request

## Description

RPC test시 Dev ops팀 요청에 따라 public IP 출력하도록 수정합니다.

Related issue: [ASSET-50](https://pi-lab.atlassian.net/browse/ASSET-50)

### Changes

- [`e2a16be`](https://github.com/bifrost-platform/asset-info-v2/pull/56/commits/e2a16bec148d9fd80b1ee4ccb03e33d481a0f175): Public IP 출력하도록 수정

### Types of Changes (multiple options can be selected)

- [ ] Create asset information
- [ ] Update asset information
- [ ] Delete asset information
- [x] Other `Settings`

## Checklist

- [x] Did you pass the tests? (Did you execute `pytest -l -all` in your PC and get a green light?)
- [x] Did you run the pre-process?
- [x] Have you added and run tests to validate the changes?
- [x] Have you updated the documentation?
- [x] Have you updated the version in `{PWD}/VERSION` if you need?


[ASSET-50]: https://pi-lab.atlassian.net/browse/ASSET-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ